### PR TITLE
EMBARK-1157 Make best prompts per agent available in default distribution

### DIFF
--- a/hooks/post-tool-use.sh
+++ b/hooks/post-tool-use.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT="$(cat)"
+SESSION_ID="$(jq -r '.session_id // empty' <<<"$INPUT")"
+TOOL_NAME="$(jq -r '.tool_name // empty' <<<"$INPUT")"
+
+if [[ -z "$SESSION_ID" || -z "$TOOL_NAME" ]]; then
+  exit 0
+fi
+
+STATE_FILE="/tmp/claude-embark-hook-${SESSION_ID}.json"
+umask 077
+
+init_state() {
+  jq -n '{
+    bootstrap_done: false,
+    read_after_bootstrap: false,
+    narrowed_retry_used: false
+  }' > "$STATE_FILE"
+}
+
+read_state() {
+  local field="$1"
+  jq -r ".$field" "$STATE_FILE"
+}
+
+write_state_expr() {
+  local expr="$1"
+  jq "$expr" "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+}
+
+if [[ ! -f "$STATE_FILE" ]]; then
+  init_state
+fi
+
+case "$TOOL_NAME" in
+  Bash)
+    COMMAND="$(jq -r '.tool_input.command // empty' <<<"$INPUT")"
+    if [[ "$COMMAND" == *"embark search"* ]]; then
+      if [[ "$COMMAND" == *" -p "* ]]; then
+        BOOTSTRAP_DONE="$(read_state bootstrap_done)"
+        NARROWED_RETRY_USED="$(read_state narrowed_retry_used)"
+
+        if [[ "$BOOTSTRAP_DONE" != "true" ]]; then
+          write_state_expr '.bootstrap_done = true'
+        elif [[ "$NARROWED_RETRY_USED" != "true" ]]; then
+          write_state_expr '.narrowed_retry_used = true'
+        fi
+      else
+        write_state_expr '.bootstrap_done = true'
+      fi
+    fi
+    ;;
+  Read)
+    if [[ "$(read_state bootstrap_done)" == "true" && "$(read_state read_after_bootstrap)" != "true" ]]; then
+      write_state_expr '.read_after_bootstrap = true'
+    fi
+    ;;
+esac
+
+exit 0

--- a/hooks/pre-tool-use.sh
+++ b/hooks/pre-tool-use.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT="$(cat)"
+SESSION_ID="$(jq -r '.session_id // empty' <<<"$INPUT")"
+TOOL_NAME="$(jq -r '.tool_name // empty' <<<"$INPUT")"
+
+if [[ -z "$SESSION_ID" || -z "$TOOL_NAME" ]]; then
+  exit 0
+fi
+
+STATE_FILE="/tmp/claude-embark-hook-${SESSION_ID}.json"
+umask 077
+
+init_state() {
+  jq -n '{
+    bootstrap_done: false,
+    read_after_bootstrap: false,
+    narrowed_retry_used: false
+  }' > "$STATE_FILE"
+}
+
+read_state() {
+  local field="$1"
+  jq -r ".$field" "$STATE_FILE"
+}
+
+deny() {
+  local reason="$1"
+  jq -n --arg reason "$reason" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $reason
+    }
+  }'
+  exit 0
+}
+
+if [[ ! -f "$STATE_FILE" ]]; then
+  init_state
+fi
+
+BOOTSTRAP_DONE="$(read_state bootstrap_done)"
+READ_AFTER_BOOTSTRAP="$(read_state read_after_bootstrap)"
+NARROWED_RETRY_USED="$(read_state narrowed_retry_used)"
+
+case "$TOOL_NAME" in
+  Bash)
+    COMMAND="$(jq -r '.tool_input.command // empty' <<<"$INPUT")"
+
+    if [[ "$COMMAND" == *"embark search"* ]]; then
+      if [[ "$COMMAND" == *" -p "* ]]; then
+        if [[ "$BOOTSTRAP_DONE" != "true" ]]; then
+          exit 0
+        fi
+
+        if [[ "$READ_AFTER_BOOTSTRAP" != "true" ]]; then
+          deny "Read at least one returned file from the bootstrap search before a semantic retry. Inspect nearby code locally first, then retry with \`embark search -p <path> ...\` if still needed."
+        fi
+
+        if [[ "$NARROWED_RETRY_USED" == "true" ]]; then
+          deny "The narrowed semantic retry has already been used. Continue from the files and directories you have already identified instead of issuing another EmbArk search."
+        fi
+        exit 0
+      fi
+
+      if [[ "$BOOTSTRAP_DONE" == "true" ]]; then
+        deny "Do not issue a second broad EmbArk search. Read a returned file first, inspect nearby code locally, and if a retry is still needed use \`embark search -p <path> ...\`."
+      fi
+      exit 0
+    fi
+
+    if [[ "$COMMAND" =~ (^|[[:space:]])(rg|grep|find)([[:space:]]|$) ]]; then
+      if [[ "$BOOTSTRAP_DONE" != "true" ]]; then
+        deny "Do not start broad local discovery before semantic bootstrap. Use one broad EmbArk search first when the relevant area is still unknown."
+      fi
+
+      if [[ "$READ_AFTER_BOOTSTRAP" != "true" ]]; then
+        deny "Read at least one returned file from the bootstrap search before switching to local search tools."
+      fi
+    fi
+
+    if [[ "$BOOTSTRAP_DONE" != "true" ]]; then
+      if [[ "$COMMAND" =~ (^|[[:space:]])git[[:space:]]+(log|show|blame)([[:space:]]|$) ]]; then
+        deny "Do not use git history for initial discovery. Start with semantic bootstrap, then inspect nearby code locally."
+      fi
+    fi
+    ;;
+  Grep)
+    if [[ "$BOOTSTRAP_DONE" != "true" ]]; then
+      deny "Do not start broad local discovery before semantic bootstrap. Use one broad EmbArk search first when the relevant area is still unknown."
+    fi
+
+    if [[ "$READ_AFTER_BOOTSTRAP" != "true" ]]; then
+      deny "Read at least one returned file from the bootstrap search before switching to local search tools."
+    fi
+    ;;
+  Glob)
+    if [[ "$BOOTSTRAP_DONE" == "true" && "$READ_AFTER_BOOTSTRAP" != "true" ]]; then
+      deny "Read at least one returned file from the bootstrap search before switching to local search tools."
+    fi
+    ;;
+esac
+
+exit 0

--- a/hooks/pre-tool-use.txt
+++ b/hooks/pre-tool-use.txt
@@ -1,1 +1,1 @@
-Tip: prefer `embark code_search` over grep/rg/find when you're looking for code by intent. Embark uses semantic search and often surfaces the right file in one call.
+Tip: if the relevant file is still unknown, use EmbArk for one broad bootstrap search, then read at least one returned file and inspect nearby code locally. If that still fails, do at most one narrowed retry: on CLI use `embark search -p <path> ...` with the best hit's directory, and on MCP set `pathFilter`. Do not issue a second broad semantic search.

--- a/hooks/user-prompt-submit.sh
+++ b/hooks/user-prompt-submit.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT="$(cat)"
+SESSION_ID="$(jq -r '.session_id // empty' <<<"$INPUT")"
+
+if [[ -z "$SESSION_ID" ]]; then
+  exit 0
+fi
+
+STATE_FILE="/tmp/claude-embark-hook-${SESSION_ID}.json"
+umask 077
+
+jq -n '{
+  bootstrap_done: false,
+  read_after_bootstrap: false,
+  narrowed_retry_used: false
+}' > "$STATE_FILE"
+
+CONTEXT="Workflow: if the relevant file or subsystem is still unclear, use semantic search before broad local discovery. After a semantic result, read at least one returned file before expanding locally with nearby files in that same directory or subsystem. If another semantic search is still needed, narrow it: on CLI use \`embark search -p <path> ...\`, and on MCP set \`pathFilter\`."
+
+jq -n --arg ctx "$CONTEXT" '{
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit",
+    additionalContext: $ctx
+  }
+}'

--- a/hooks/user-prompt-submit.txt
+++ b/hooks/user-prompt-submit.txt
@@ -1,1 +1,1 @@
-Tip: when you need to locate code in this repo, try `embark code_search` before grep/rg/find. Semantic search CLI tends to surface the right files in fewer turns.
+Tip: when the relevant file is unknown, do one broad EmbArk search first, then read at least one returned file and inspect nearby code locally. If that still fails, do at most one narrowed retry: on CLI use `embark search -p <path> ...` with the best hit's directory, and on MCP set `pathFilter`. Do not issue a second broad semantic search.

--- a/instructions/claude/embark-instructions-aggressive.md
+++ b/instructions/claude/embark-instructions-aggressive.md
@@ -1,0 +1,17 @@
+# Tools
+
+## Semantic Code Search (EmbArk)
+
+You have access to `embark search` for searching the codebase semantically.
+Use the `/embark-search` skill or run `embark search "<query>"` to find code by meaning, not just keywords.
+
+### MANDATORY: EmbArk First Bootstrap
+
+When no relevant file or subsystem is known yet, you MUST start code search with `embark search`.
+
+- Do one broad `embark search` first.
+- Make the first query specific to the issue's named feature, class, method, config flag, or behavior when available.
+- After the first search, open at least one returned file and inspect it locally.
+- If the first hit is relevant but incomplete, inspect neighboring files locally in that same directory or subsystem before any semantic retry.
+- After the first relevant file or path is known, prefer direct file reads and exact search to inspect nearby code.
+- If a semantic retry is still needed, narrow it with `embark search -p <path> ...` using the directory of the best first hit.

--- a/instructions/claude/embark-instructions-mcp-aggressive.md
+++ b/instructions/claude/embark-instructions-mcp-aggressive.md
@@ -1,0 +1,17 @@
+# Tools
+
+## Semantic Code Search (EmbArk)
+
+You have access to the EmbArk MCP `code_search` tool for searching the codebase semantically.
+This tool can search for code snippets related in meaning to the search query and search objective.
+
+### MANDATORY: EmbArk First Bootstrap
+
+When no relevant file or subsystem is known yet, you MUST start code search with `code_search`.
+
+- Do one broad `code_search` first.
+- Make the first query specific to the issue's named feature, class, method, config flag, or behavior when available.
+- After the first search, open at least one returned file and inspect it locally.
+- If the first hit is relevant but incomplete, inspect neighboring files locally in that same directory or subsystem before any semantic retry.
+- After the first relevant file or path is known, prefer direct file reads and exact search to inspect nearby code.
+- If a semantic retry is still needed, set `pathFilter` to the directory of the best first hit.

--- a/instructions/claude/embark-instructions-mcp.md
+++ b/instructions/claude/embark-instructions-mcp.md
@@ -1,0 +1,17 @@
+# Tools
+
+## Semantic Code Search (EmbArk)
+
+You have access to the EmbArk MCP `code_search` tool for searching the codebase semantically.
+This tool can search for code snippets related in meaning to the search query and search objective.
+
+### Single-Shot Policy
+
+Use `code_search` as a semantic bootstrap when the relevant file or subsystem is still unknown.
+
+- If no relevant file is open yet, start with one `code_search`.
+- Make the first query specific to the issue's named feature, class, method, config flag, or behavior when available.
+- After the first search, open at least one returned file and inspect it locally.
+- If the first hit is relevant but incomplete, inspect neighboring files locally in that same directory or subsystem before any semantic retry.
+- After the first relevant file or path is known, prefer direct file reads and exact search to inspect nearby code.
+- If a semantic retry is still needed, set `pathFilter` to the directory of the best first hit.

--- a/instructions/claude/embark-instructions-noskills-aggressive.md
+++ b/instructions/claude/embark-instructions-noskills-aggressive.md
@@ -1,0 +1,42 @@
+# Tools
+
+## Semantic Code Search (EmbArk)
+
+You have access to `embark search` for searching the codebase semantically.
+It finds code by meaning, not just keywords.
+
+### MANDATORY: EmbArk First Bootstrap
+
+When no relevant file or subsystem is known yet, you MUST start code search with `embark search`.
+
+### Usage
+
+```bash
+embark search "<detailed and descriptive query>"
+embark search -p <path> "<query>"  # <path> must be relative to the project root
+```
+
+### Query Tips
+
+- Be descriptive: "function that validates user email addresses" > "email"
+- Include context: "error handling middleware for HTTP requests with logging"
+- Specify what you're looking for: "React component that renders a modal dialog"
+
+- Do one broad `embark search` first.
+- Make the first query specific to the issue's named feature, class, method, config flag, or behavior when available.
+- After the first search, open at least one returned file and inspect it locally.
+- If the first hit is relevant but incomplete, inspect neighboring files locally in that same directory or subsystem before any semantic retry.
+- After the first relevant file or path is known, prefer direct file reads and exact search to inspect nearby code.
+- If a semantic retry is still needed, use `embark search -p <path> ...` with the directory of the best first hit.
+
+### Examples
+
+```bash
+# Find authentication-related code
+embark search "user authentication login flow"
+
+# Narrow to specific directory
+embark search -p src/auth "JWT token validation"
+```
+
+Use `embark search` once to get the initial pointer, then inspect nearby code locally. If that still fails, do a narrowed retry with `-p`.

--- a/instructions/claude/embark-instructions-noskills.md
+++ b/instructions/claude/embark-instructions-noskills.md
@@ -1,0 +1,42 @@
+# Tools
+
+## Semantic Code Search (EmbArk)
+
+You have access to `embark search` for searching the codebase semantically.
+It finds code by meaning, not just keywords.
+
+### Usage
+
+```bash
+embark search "<detailed and descriptive query>"
+embark search -p <path> "<query>"  # <path> must be relative to the project root
+```
+
+### Query Tips
+
+- Be descriptive: "function that validates user email addresses" > "email"
+- Include context: "error handling middleware for HTTP requests with logging"
+- Specify what you're looking for: "React component that renders a modal dialog"
+
+### Single-Shot Policy
+
+Use `embark search` as a semantic bootstrap when the relevant file or subsystem is still unknown.
+
+- If no relevant file is open yet, start with one `embark search`.
+- Make the first query specific to the issue's named feature, class, method, config flag, or behavior when available.
+- After the first search, open at least one returned file and inspect it locally.
+- If the first hit is relevant but incomplete, inspect neighboring files locally in that same directory or subsystem before any semantic retry.
+- After the first relevant file or path is known, prefer direct file reads and exact search to inspect nearby code.
+- If a semantic retry is still needed, use `embark search -p <path> ...` with the directory of the best first hit.
+
+### Examples
+
+```bash
+# Find authentication-related code
+embark search "user authentication login flow"
+
+# Narrow to specific directory
+embark search -p src/auth "JWT token validation"
+```
+
+Use `embark search` once to get the initial pointer, then inspect nearby code locally. If that still fails, do a narrowed retry with `-p`.

--- a/instructions/claude/embark-instructions.md
+++ b/instructions/claude/embark-instructions.md
@@ -1,0 +1,17 @@
+# Tools
+
+## Semantic Code Search (EmbArk)
+
+You have access to `embark search` for searching the codebase semantically.
+Use the `/embark-search` skill or run `embark search "<query>"` to find code by meaning, not just keywords.
+
+### Single-Shot Policy
+
+Use `embark search` as a semantic bootstrap when the relevant file or subsystem is still unknown.
+
+- If no relevant file is open yet, start with one `embark search`.
+- Make the first query specific to the issue's named feature, class, method, config flag, or behavior when available.
+- After the first search, open at least one returned file and inspect it locally.
+- If the first hit is relevant but incomplete, inspect neighboring files locally in that same directory or subsystem before any semantic retry.
+- After the first relevant file or path is known, prefer direct file reads and exact search to inspect nearby code.
+- If a semantic retry is still needed, use `embark search -p <path> ...` with the directory of the best first hit.

--- a/instructions/embark-instructions-aggressive.md
+++ b/instructions/embark-instructions-aggressive.md
@@ -5,24 +5,13 @@
 You have access to `embark search` for searching the codebase semantically.
 Use the `/embark-search` skill or run `embark search "<query>"` to find code by meaning, not just keywords.
 
-### MANDATORY: Always use EmbArk for code search
+### MANDATORY: Use EmbArk first for code discovery
 
-You MUST use `embark search` as your PRIMARY and DEFAULT method for all code search operations. Do NOT use grep, ripgrep, find, or any other text-based search tool when looking for code. EmbArk semantic search is strictly superior to keyword-based search — it understands code meaning, context, and intent.
+You MUST start code search with `embark search` before planning, editing, or exact search when you do not yet know the right file, subsystem, implementation, or related test. This is the default entry point for unfamiliar-code discovery.
 
-**NEVER use grep or text search for**:
-- Finding function/class/variable definitions or usages
-- Understanding how a feature is implemented
-- Locating code related to a concept or behavior
-- Exploring unfamiliar parts of the codebase
-- Searching before making any code changes
-
-**ALWAYS use `embark search` instead.** This is non-negotiable. Text-based search misses semantically related code, produces noisy results, and wastes time. EmbArk finds what you actually need.
-
-### When to use semantic search:
-- Understanding unfamiliar codebases or locating specific functionality.
-- Finding implementations, definitions, or usage patterns.
-- Identifying code related to specific features or concepts.
-- Before making changes to understand the context and impact.
-- ANY time you would otherwise reach for grep, ripgrep, or find.
-
-Use this tool FIRST and ALWAYS when you need to understand code structure or locate relevant implementations. Do not fall back to text search.
+- Use one focused natural-language query per search.
+- Do NOT start with grep, ripgrep, or find while the search problem is still semantic or exploratory.
+- Inspect the first relevant file or directory before issuing another broad semantic search.
+- Use another broad `embark search` only if the local path stops being productive.
+- Once you know the relevant file, symbol, or directory, switch to direct file reads or exact search for local inspection.
+- If you search again after finding a relevant area, narrow with `-p <path>`.

--- a/instructions/embark-instructions-mcp-aggressive.md
+++ b/instructions/embark-instructions-mcp-aggressive.md
@@ -5,24 +5,13 @@
 You have access to the EmbArk MCP `code_search` tool for searching the codebase semantically.
 This tool can search for code snippets related in meaning to the search query and search objective.
 
-### MANDATORY: Always use EmbArk for code search
+### MANDATORY: Use EmbArk first for code discovery
 
-You MUST use the `code_search` tool as your PRIMARY and DEFAULT method for all code search operations. Do NOT use grep, ripgrep, find, or any other text-based search tool when looking for code. EmbArk semantic search is strictly superior to keyword-based search — it understands code meaning, context, and intent.
+You MUST start code search with `code_search` before planning, editing, or exact search when you do not yet know the right file, subsystem, implementation, or related test. This is the default entry point for unfamiliar-code discovery.
 
-**NEVER use grep or text search for**:
-- Finding function/class/variable definitions or usages
-- Understanding how a feature is implemented
-- Locating code related to a concept or behavior
-- Exploring unfamiliar parts of the codebase
-- Searching before making any code changes
-
-**ALWAYS use `code_search` instead.** This is non-negotiable. Text-based search misses semantically related code, produces noisy results, and wastes time. EmbArk finds what you actually need.
-
-### When to use semantic search:
-- Understanding unfamiliar codebases or locating specific functionality.
-- Finding implementations, definitions, or usage patterns.
-- Identifying code related to specific features or concepts.
-- Before making changes to understand the context and impact.
-- ANY time you would otherwise reach for grep, ripgrep, or find.
-
-Use this tool FIRST and ALWAYS when you need to understand code structure or locate relevant implementations. Do not fall back to text search.
+- Use one focused natural-language query per search.
+- Do NOT start with grep, ripgrep, or find while the search problem is still semantic or exploratory.
+- Inspect the first relevant file or directory before issuing another broad semantic search.
+- Use another broad `code_search` only if the local path stops being productive.
+- Once you know the relevant file, symbol, or directory, switch to direct file reads or exact search for local inspection.
+- If you search again after finding a relevant area, narrow with `pathFilter`.

--- a/instructions/embark-instructions-mcp.md
+++ b/instructions/embark-instructions-mcp.md
@@ -5,10 +5,11 @@
 You have access to the EmbArk MCP `code_search` tool for searching the codebase semantically.
 This tool can search for code snippets related in meaning to the search query and search objective.
 
-### When to use semantic search:
-- Understanding unfamiliar codebases or locating specific functionality.
-- Finding implementations, definitions, or usage patterns.
-- Identifying code related to specific features or concepts.
-- Before making changes to understand the context and impact.
-
-Use this tool proactively when you need to understand code structure or locate relevant implementations.
+### How to use it
+- Start with `code_search` before planning, editing, or exact search in unfamiliar code when you do not yet know the right file, subsystem, implementation, or related test.
+- Use one focused natural-language query per search.
+- Do not start with grep, ripgrep, or find when the search problem is still semantic or exploratory.
+- Inspect the first relevant file or directory before issuing another broad semantic search.
+- Use another broad `code_search` only if the local path stops being productive.
+- Once you know the relevant file, symbol, or directory, switch to direct file reads or exact search for local inspection.
+- If you search again after finding a relevant area, narrow with `pathFilter`.

--- a/instructions/embark-instructions-noskills-aggressive.md
+++ b/instructions/embark-instructions-noskills-aggressive.md
@@ -7,16 +7,7 @@ It finds code by meaning, not just keywords.
 
 ### MANDATORY: Always use EmbArk for code search
 
-You MUST use `embark search` as your PRIMARY and DEFAULT method for all code search operations. Do NOT use grep, ripgrep, find, or any other text-based search tool when looking for code. EmbArk semantic search is strictly superior to keyword-based search — it understands code meaning, context, and intent.
-
-**NEVER use grep or text search for**:
-- Finding function/class/variable definitions or usages
-- Understanding how a feature is implemented
-- Locating code related to a concept or behavior
-- Exploring unfamiliar parts of the codebase
-- Searching before making any code changes
-
-**ALWAYS use `embark search` instead.** This is non-negotiable. Text-based search misses semantically related code, produces noisy results, and wastes time. EmbArk finds what you actually need.
+You MUST start code search with `embark search` before planning, editing, or exact search when you do not yet know the right file, subsystem, implementation, or related test. This is the default entry point for unfamiliar-code discovery.
 
 ### Usage
 
@@ -31,12 +22,12 @@ embark search -p <path> "<query>"  # <path> must be relative to the project root
 - Include context: "error handling middleware for HTTP requests with logging"
 - Specify what you're looking for: "React component that renders a modal dialog"
 
-### When to use semantic search:
-- Understanding unfamiliar codebases or locating specific functionality.
-- Finding implementations, definitions, or usage patterns.
-- Identifying code related to specific features or concepts.
-- Before making changes to understand the context and impact.
-- ANY time you would otherwise reach for grep, ripgrep, or find.
+- Use one focused natural-language query per search.
+- Do NOT start with grep, ripgrep, or find while the search problem is still semantic or exploratory.
+- Inspect the first relevant file or directory before issuing another broad semantic search.
+- Use another broad `embark search` only if the local path stops being productive.
+- Once you know the relevant file, symbol, or directory, switch to direct file reads or exact search for local inspection.
+- If you search again after finding a relevant area, narrow with `-p <path>`.
 
 ### Examples
 
@@ -54,4 +45,4 @@ embark search "calls to handleRequest to understand impact"
 embark search -p test "tests for authentication middleware"
 ```
 
-Use `embark search` FIRST and ALWAYS when you need to understand code structure or locate relevant implementations. Do not fall back to text search.
+Use `embark search` first for discovery, inspect the first good hit, then move to exact/local inspection once the target area is known.

--- a/instructions/embark-instructions-noskills.md
+++ b/instructions/embark-instructions-noskills.md
@@ -18,11 +18,15 @@ embark search -p <path> "<query>"  # <path> must be relative to the project root
 - Include context: "error handling middleware for HTTP requests with logging"
 - Specify what you're looking for: "React component that renders a modal dialog"
 
-### When to use semantic search:
-- Understanding unfamiliar codebases or locating specific functionality.
-- Finding implementations, definitions, or usage patterns.
-- Identifying code related to specific features or concepts.
-- Before making changes to understand the context and impact.
+### How to use it
+
+- Start with `embark search` before planning, editing, or exact search in unfamiliar code when you do not yet know the right file, subsystem, implementation, or related test.
+- Use one focused natural-language query per search.
+- Do not start with grep, ripgrep, or find when the search problem is still semantic or exploratory.
+- Inspect the first relevant file or directory before issuing another broad semantic search.
+- Use another broad `embark search` only if the local path stops being productive.
+- Once you know the relevant file, symbol, or directory, switch to direct file reads or exact search for local inspection.
+- If you search again after finding a relevant area, narrow with `-p <path>`.
 
 ### Examples
 
@@ -40,4 +44,4 @@ embark search "calls to handleRequest to understand impact"
 embark search -p test "tests for authentication middleware"
 ```
 
-Use `embark search` proactively when you need to understand code structure or locate relevant implementations.
+Use `embark search` for discovery, inspect the first good hit, then move to exact/local inspection once the target area is known.

--- a/instructions/embark-instructions.md
+++ b/instructions/embark-instructions.md
@@ -5,10 +5,11 @@
 You have access to `embark search` for searching the codebase semantically.
 Use the `/embark-search` skill or run `embark search "<query>"` to find code by meaning, not just keywords.
 
-### When to use semantic search:
-- Understanding unfamiliar codebases or locating specific functionality.
-- Finding implementations, definitions, or usage patterns.
-- Identifying code related to specific features or concepts.
-- Before making changes to understand the context and impact.
-
-Use this tool proactively when you need to understand code structure or locate relevant implementations.
+### How to use it
+- Start with `embark search` before planning, editing, or exact search in unfamiliar code when you do not yet know the right file, subsystem, implementation, or related test.
+- Use one focused natural-language query per search.
+- Do not start with grep, ripgrep, or find when the search problem is still semantic or exploratory.
+- Inspect the first relevant file or directory before issuing another broad semantic search.
+- Use another broad `embark search` only if the local path stops being productive.
+- Once you know the relevant file, symbol, or directory, switch to direct file reads or exact search for local inspection.
+- If you search again after finding a relevant area, narrow with `-p <path>`.


### PR DESCRIPTION
- Leave instructions for Codex and other agents in the main `/instructions/`
- Overried instructions for Claude specifically in the sub-folder `/instructions/claude`
- For the context -- see https://jetbrains.slack.com/archives/C0ASKUZ395H/p1779209223109799?thread_ts=1779206134.102189&cid=C0ASKUZ395H

I took the best prompts based on the [experiments](https://docs.google.com/document/d/1mipuXSnhsxS3pkp4e5YIzsE_ex-FCHiLmlycYvW7924/edit?usp=sharing):
- Claude Code: [hooks_relax](https://github.com/JetBrains/embark/tree/artemk/hooks_relax) / [Claude Code](https://github.com/JetBrains/embark/tree/claude_code)
- Codex: [mgrep_3](https://github.com/embark-incubator/instructions/tree/artemk/mgrep_3) / [Codex](https://github.com/JetBrains/embark/tree/codex)