### PR TITLE
Tune subagent instructions: clearer CLI-vs-subagent line, cheaper model, better query example

### DIFF
--- a/agents/codex/context-explorer.toml
+++ b/agents/codex/context-explorer.toml
@@ -3,6 +3,7 @@
 # personal agent or `.codex/agents/` for a project-scoped one.
 name = "context_explorer"
 description = "Read-only codebase explorer that finds code by meaning using jbcontext semantic search. Give it a 1-2 sentence intent (what to understand or locate). It runs up to 3 `jbcontext search` queries, reads the promising files to verify, and returns concrete file:line references with inline code snippets plus a confidence note — so the parent agent does not have to re-read the same files. Use for 'where is X', 'how does Y work', or behavior described without exact symbol names. Skip when the task already names an exact file, class, or symbol; keyword grep is faster there."
+model = "gpt-5.6-luna"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 nickname_candidates = ["Scout", "Cartographer", "Pathfinder", "Ranger"]

--- a/instructions/codex/context-instructions-subagent.md
+++ b/instructions/codex/context-instructions-subagent.md
@@ -45,3 +45,8 @@ explicit instruction to spawn it:
 
 Skip the subagent and search inline (or grep) when you already know an
 exact relevant file, class, or symbol, or when a single query is obviously enough.
+
+### How to spawn it
+
+- Spawn it with: `spawn_agent(agent_type="context_explorer", fork_turns="none", message="<intent>")`
+- Always call `wait_agent` after spawning, or you'll never get its report and end up re-exploring everything yourself.

--- a/instructions/codex/context-instructions-subagent.md
+++ b/instructions/codex/context-instructions-subagent.md
@@ -12,6 +12,12 @@ jbcontext search "<detailed and descriptive query>"
 jbcontext search -p <path> "<query>"  # <path> must be relative to the project root
 ```
 
+### Query Tips
+
+- Be descriptive: "Where is a function that validates user email addresses" > "email"
+- Include context: "Find error handling middleware for HTTP requests with logging"
+- Specify what you're looking for: "React component that renders a modal dialog"
+
 ### How to use it
 - Start with `jbcontext search` before planning, editing, or exact search in unfamiliar code when you do not yet know the right file, subsystem, implementation, or related test.
 - Use one focused natural-language query per search.

--- a/instructions/codex/context-instructions-subagent.md
+++ b/instructions/codex/context-instructions-subagent.md
@@ -22,9 +22,7 @@ jbcontext search -p <path> "<query>"  # <path> must be relative to the project r
 - Start with `jbcontext search` before planning, editing, or exact search in unfamiliar code when you do not yet know the right file, subsystem, implementation, or related test.
 - Use one focused natural-language query per search.
 - Do not start with grep, ripgrep, or find when the search problem is still semantic or exploratory.
-- Inspect the first relevant file or directory before issuing another broad semantic search.
-- Once you know the relevant file, symbol, or directory, switch to direct file reads or exact search for local inspection.
-- If you search again after finding a relevant area, narrow with `-p <path>`.
+- Once you get a relevant hit, switch to direct file reads — needing another search is a sign to delegate to `context_explorer` instead of searching again yourself.
 
 ## Subagent: `context_explorer`
 
@@ -35,18 +33,15 @@ returns concrete `file:line` references with inline code snippets and a
 confidence note — so this thread stays uncluttered by intermediate search output
 and does not have to re-read the same files.
 
-Spawn `context_explorer` when a task matches any of these — treat this as the
-explicit instruction to spawn it:
-- The task describes behavior or intent ("where is X", "how does Y work") without
-  naming an exact file or symbol, and answering it will likely take more than one
-  search.
-- You need to map an unfamiliar subsystem, or trace an execution path across
-  several files, before making a change.
-
-Skip the subagent and search inline (or grep) when you already know an
-exact relevant file, class, or symbol, or when a single query is obviously enough.
-
 ### How to spawn it
 
 - Spawn it with: `spawn_agent(agent_type="context_explorer", fork_turns="none", message="<intent>")`
-- Always call `wait_agent` after spawning, or you'll never get its report and end up re-exploring everything yourself.
+- `spawn_agent` runs in the background — you can read a file you already know is relevant, check the environment, but don't perform exploration while it's running.
+- Always call `wait_agent` once that known work (if any) is done, otherwise you never get the report.
+
+
+## When to use `jbcontext search` CLI vs. `context_explorer` subagent
+
+If you're confident the discovery is multi-step — mapping an unfamiliar
+subsystem, or tracing across several files — spawn `context_explorer`
+directly. Otherwise, run `jbcontext search` first; if the results are not enough, delegate to `context_explorer`.

--- a/instructions/codex/context-instructions-subagent.md
+++ b/instructions/codex/context-instructions-subagent.md
@@ -36,13 +36,6 @@ explicit instruction to spawn it:
   search.
 - You need to map an unfamiliar subsystem, or trace an execution path across
   several files, before making a change.
-- You want to explore several angles at once — e.g. one `context_explorer` per
-  subsystem or per open question — and collect the results together.
 
-Skip the subagent and search inline (or grep) when the task already names an
-exact file, class, or symbol, or when a single query is obviously enough.
-
-Codex spawns subagents only when explicitly asked, so treat the criteria above as
-that ask: when a task matches, spawn `context_explorer` as part of carrying it
-out. The user can also request it directly at any time (for example, "use
-`context_explorer` to map the auth flow").
+Skip the subagent and search inline (or grep) when you already know an
+exact relevant file, class, or symbol, or when a single query is obviously enough.


### PR DESCRIPTION
I tried to draw a clearer line between when to use the `context_explorer` subagent vs. inline `jbcontext search` CLI: prefer inline search when a single query is likely enough or when unsure; escalate to the subagent only for genuinely multi-step/unfamiliar exploration. I also switched the subagent to the cheapest model (gpt-5.6-luna).

Also improved the query examples, which noticeably pushed the model toward more natural-language queries rather than keyword searches.

Fixed incorrect tool/subagent usage patterns (missed `wait_agent` calls, redundant re-search, ignored subagent warnings) and fixed the prompt.
