### PR TITLE
Preview publishing results

### DIFF
--- a/results/README.md
+++ b/results/README.md
@@ -1,0 +1,82 @@
+# Published eval results
+
+
+```
+results/
+  index.json                                 every dataset and arm below, for enumeration
+  <dataset>/
+    dataset.json                             properties of the task set: size, files, LOC, taskCount
+    <harness>+<model>+<effort>/              one directory per measured cell
+      baseline.json                          the arm run WITHOUT jbcontext
+      jbcontext.json                         the arm run WITH it
+```
+
+`index.json` is required.
+
+## Aggregates versus per-task
+
+`tasks[]` is optional and changes how the cell is labelled, never how much it is trusted:
+
+| Published            | Row label         | Sample                          |
+| -------------------- | ----------------- | ------------------------------- |
+| `tasks[]` both arms  | `measured`        | tasks paired by `taskId`        |
+| aggregates only      | `dataset-average` | the dataset's task count        |
+
+With per-task metrics one dataset can also split into several rows by each task's own `sizeLabel`.
+
+## Adding a dataset
+
+1. Write `<dataset>/dataset.json` and both arms of each cell.
+2. Add the dataset and its arm directory names to `index.json`.
+3. Validate — see below. Do this before opening the PR; it is the only step that checks the numbers
+   rather than the files.
+
+## Validate
+
+```
+jbcontext analyze --check-results .                                       # this checkout
+jbcontext analyze --check-results . --json-output                         # same findings, for CI to parse
+jbcontext analyze --check-results https://github.com/jetbrains/context    # what main publishes right now
+jbcontext analyze --check-results https://github.com/jetbrains/context/tree/my-branch
+```
+
+A healthy tree looks like this:
+
+```
+  Published eval results · /path/to/context
+  Datasets      3 · monorepo-swebench, oss-swe-bench, swe-bench-pro
+  Cells         3 with both arms parsed
+  Rows          3 · 3 dataset-average
+
+    claude opus high XL          cost +0.34 · turns +0.41 · explorationTime +0.15 · resolution +0.00 · dataset-average n=175
+    claude opus high XS          cost +0.06 · toolCalls +0.06 · turns +0.14 · explorationTime +0.04 · dataset-average n=205
+    codex gpt-5.3-codex high XL  cost -0.07 · explorationTime -0.01 · resolution -0.05 · dataset-average n=731
+
+  Default       cost +0.06 · toolCalls +0.06 · turns +0.14 · explorationTime +0.04 · extrapolated
+  Unmeasured    tokens — reported as n/a, never as 0
+
+  Problems      none
+
+  OK — 3 rows from 3 datasets.
+```
+
+Read the **Rows** block against what you meant to publish. Every failure mode below produces a tree
+that parses and validates and is still wrong, which is why file-level checks cannot catch them:
+
+| What went wrong                             | What you would otherwise ship                       |
+| ------------------------------------------- | --------------------------------------------------- |
+| both arms are the same file                 | every effect `0.00`, labelled as a real measurement |
+| the arms are swapped                        | every effect with its sign inverted                 |
+| a metric in one arm only                    | that metric silently absent                         |
+| a metric paired on too few tasks            | a quotient of reporting coverage, not of the effect |
+| a zero baseline, or a zero jbcontext arm    | a division by zero, or a "100% saving"              |
+| two datasets publishing the same cell       | one of them measured to no effect                   |
+| a row no query can reach                    | numbers published that no session ever reads        |
+
+The last two are the ones worth re-reading the output for: nothing about the files is wrong, and the
+measurement simply never surfaces. `--check-results` reports them as `unreachable`.
+
+Also useful:
+
+- `jbcontext analyze --json-output` on real sessions exposes the resolved table under `projection`,
+  including which cell each number came from.

--- a/results/index.json
+++ b/results/index.json
@@ -1,0 +1,33 @@
+{
+  "$comment": [
+    "Manifest of the published eval results. It exists because neither way the CLI reads these files",
+    "can list a directory: a nativeCompile binary sees only what its resource whitelist names, and",
+    "`jbcontext setup-agent --prompts-location` fetches raw.githubusercontent.com paths one at a time.",
+    "So a dataset or arm that is not named here is invisible, and publishing a new one is a commit to",
+    "this file rather than a CLI release.",
+    "",
+    "Every name here is one path segment: it is interpolated into local paths under ~/.jbcontext/prompts",
+    "and the CLI refuses anything that could escape that directory.",
+    "",
+    "Layout, per dataset:",
+    "  <dataset>/dataset.json                       properties of the task set",
+    "  <dataset>/<harness>+<model>+<effort>/        one directory per measured cell",
+    "    baseline.json                              the arm run WITHOUT jbcontext",
+    "    jbcontext.json                             the arm run WITH it"
+  ],
+  "schema": "jbcontext-eval-results/1",
+  "datasets": [
+    {
+      "name": "monorepo-swebench",
+      "arms": ["claude-code+opus+high"]
+    },
+    {
+      "name": "oss-swe-bench",
+      "arms": ["claude-code+opus+high"]
+    },
+    {
+      "name": "swe-bench-pro",
+      "arms": ["codex+gpt-5.3-codex+high"]
+    }
+  ]
+}

--- a/results/monorepo-swebench/claude-code+opus+high/baseline.json
+++ b/results/monorepo-swebench/claude-code+opus+high/baseline.json
@@ -1,0 +1,25 @@
+{
+  "$comment": [
+    "FIRST ITERATION — the ratios against jbcontext.json are the measured V1.2 Table 1 figures",
+    "(EMBARK-1136): cost -34%, turns -41%, exploration time -15%, task resolution unchanged. The",
+    "absolute per-task means below are placeholders chosen to reproduce exactly those ratios, and are",
+    "to be replaced by a harbor_eval_summary export. `run` is omitted rather than invented, so rows",
+    "derived from this cell carry no run reference yet.",
+    "",
+    "Tool calls and tokens are absent from the V1.2 monorepo table, so they are absent here — the",
+    "projection then reports them as unmeasured instead of as an effect of zero."
+  ],
+  "schema": "jbcontext-eval-arm/1",
+  "arm": "baseline",
+  "dataset": "monorepo-swebench",
+  "harness": "claude-code",
+  "model": "claude-opus-4-8",
+  "effort": "high",
+  "taskCount": 175,
+  "resolvedRate": 0.40,
+  "metrics": {
+    "costUsd": 2.0,
+    "turns": 20.0,
+    "latencyMs": 600000
+  }
+}

--- a/results/monorepo-swebench/claude-code+opus+high/jbcontext.json
+++ b/results/monorepo-swebench/claude-code+opus+high/jbcontext.json
@@ -1,0 +1,25 @@
+{
+  "$comment": [
+    "FIRST ITERATION — see baseline.json. Placeholder magnitudes, measured ratios:",
+    "  cost             1 - 1.32/2.0        = 0.34",
+    "  turns            1 - 11.8/20.0       = 0.41",
+    "  explorationTime  1 - 510000/600000   = 0.15",
+    "  resolvedRate     0.40 - 0.40         = 0.00 (unchanged)",
+    "",
+    "Integration under test was the CLI plus the search subagent and hooks."
+  ],
+  "schema": "jbcontext-eval-arm/1",
+  "arm": "jbcontext",
+  "dataset": "monorepo-swebench",
+  "harness": "claude-code",
+  "model": "claude-opus-4-8",
+  "effort": "high",
+  "integration": "cli+subagent+hooks",
+  "taskCount": 175,
+  "resolvedRate": 0.40,
+  "metrics": {
+    "costUsd": 1.32,
+    "turns": 11.8,
+    "latencyMs": 510000
+  }
+}

--- a/results/monorepo-swebench/dataset.json
+++ b/results/monorepo-swebench/dataset.json
@@ -1,0 +1,14 @@
+{
+  "$comment": [
+    "Private production monorepo, SWE-bench-style tasks. Properties of the TASK SET, so this file is",
+    "written once per dataset and shared by both arms of every cell under it.",
+    "",
+    "`sizeLabel` lives here rather than per task because a per-dataset label is what the eval pipeline",
+    "publishes today. A dataset whose arms carry per-task sizeLabels splits into several rows instead."
+  ],
+  "name": "monorepo-swebench",
+  "sizeLabel": "XL",
+  "files": 1200000,
+  "loc": 48000000,
+  "taskCount": 175
+}

--- a/results/oss-swe-bench/claude-code+opus+high/baseline.json
+++ b/results/oss-swe-bench/claude-code+opus+high/baseline.json
@@ -1,0 +1,26 @@
+{
+  "$comment": [
+    "FIRST ITERATION — the ratios against jbcontext.json are the measured V1.2 Table 3 figures",
+    "(EMBARK-1136): cost -6%, tool calls -6%, turns -14%, exploration time -4%, task resolution +4",
+    "points. The absolute per-task means below are placeholders chosen to reproduce exactly those",
+    "ratios, and are to be replaced by a harbor_eval_summary export.",
+    "",
+    "The small-repo effects being several times smaller than the monorepo ones is the point of keeping",
+    "size in the cell key: the per-metric ratios between the two differ (cost ~0.17, tool calls ~0.18,",
+    "turns ~0.34), so no single per-size multiplier could fit them all."
+  ],
+  "schema": "jbcontext-eval-arm/1",
+  "arm": "baseline",
+  "dataset": "oss-swe-bench",
+  "harness": "claude-code",
+  "model": "claude-opus-4-8",
+  "effort": "high",
+  "taskCount": 205,
+  "resolvedRate": 0.50,
+  "metrics": {
+    "costUsd": 1.0,
+    "toolCalls": 50.0,
+    "turns": 10.0,
+    "latencyMs": 100000
+  }
+}

--- a/results/oss-swe-bench/claude-code+opus+high/jbcontext.json
+++ b/results/oss-swe-bench/claude-code+opus+high/jbcontext.json
@@ -1,0 +1,26 @@
+{
+  "$comment": [
+    "FIRST ITERATION — see baseline.json. Placeholder magnitudes, measured ratios:",
+    "  cost             1 - 0.94/1.0        = 0.06",
+    "  toolCalls        1 - 47.0/50.0       = 0.06",
+    "  turns            1 - 8.6/10.0        = 0.14",
+    "  explorationTime  1 - 96000/100000    = 0.04",
+    "  resolvedRate     0.54 - 0.50         = +0.04 (reported as a signed resolution change, never as",
+    "                                         a saving)"
+  ],
+  "schema": "jbcontext-eval-arm/1",
+  "arm": "jbcontext",
+  "dataset": "oss-swe-bench",
+  "harness": "claude-code",
+  "model": "claude-opus-4-8",
+  "effort": "high",
+  "integration": "cli+subagent+hooks",
+  "taskCount": 205,
+  "resolvedRate": 0.54,
+  "metrics": {
+    "costUsd": 0.94,
+    "toolCalls": 47.0,
+    "turns": 8.6,
+    "latencyMs": 96000
+  }
+}

--- a/results/oss-swe-bench/dataset.json
+++ b/results/oss-swe-bench/dataset.json
@@ -1,0 +1,12 @@
+{
+  "$comment": [
+    "OSS SWE-bench: 205 Java/C#/Python tasks in repositories of roughly 1K-20K files.",
+    "",
+    "Pending per-task size labels this is the whole dataset at one label; once the arms carry per-task",
+    "`sizeLabel` it will split into XS and S rows on its own, with no change here."
+  ],
+  "name": "oss-swe-bench",
+  "sizeLabel": "XS",
+  "loc": 900000,
+  "taskCount": 205
+}

--- a/results/swe-bench-pro/codex+gpt-5.6-sol+xhigh/baseline.json
+++ b/results/swe-bench-pro/codex+gpt-5.6-sol+xhigh/baseline.json
@@ -1,0 +1,24 @@
+{
+  "$comment": [
+    "FIRST ITERATION — the ratios against jbcontext.json are a measured REGRESSION: +7% cost, +1%",
+    "exploration time, -5 points of task resolution. The absolute per-task means below are placeholders",
+    "chosen to reproduce exactly those ratios, and are to be replaced by a harbor_eval_summary export.",
+    "",
+    "This cell is why effects are signed and why they are keyed by harness. Codex explores MORE with",
+    "jbcontext here (~1.3 search calls per task against Claude's ~0.64, plus extra Grep and Bash on the",
+    "main agent), and a projection that could not store a negative number could not report it at all.",
+    "It belongs to Codex alone: it is deliberately not carried over to any other harness."
+  ],
+  "schema": "jbcontext-eval-arm/1",
+  "arm": "baseline",
+  "dataset": "swe-bench-pro",
+  "harness": "codex",
+  "model": "gpt-5.6-sol",
+  "effort": "xhigh",
+  "taskCount": 731,
+  "resolvedRate": 0.45,
+  "metrics": {
+    "costUsd": 1.0,
+    "latencyMs": 100000
+  }
+}

--- a/results/swe-bench-pro/codex+gpt-5.6-sol+xhigh/jbcontext.json
+++ b/results/swe-bench-pro/codex+gpt-5.6-sol+xhigh/jbcontext.json
@@ -1,0 +1,21 @@
+{
+  "$comment": [
+    "FIRST ITERATION — see baseline.json. Placeholder magnitudes, measured ratios:",
+    "  cost             1 - 1.07/1.0        = -0.07 (7% MORE expensive)",
+    "  explorationTime  1 - 101000/100000   = -0.01 (1% slower)",
+    "  resolvedRate     0.40 - 0.45         = -0.05 (5 points fewer tasks resolved)"
+  ],
+  "schema": "jbcontext-eval-arm/1",
+  "arm": "jbcontext",
+  "dataset": "swe-bench-pro",
+  "harness": "codex",
+  "model": "gpt-5.6-sol",
+  "effort": "xhigh",
+  "integration": "mcp",
+  "taskCount": 731,
+  "resolvedRate": 0.40,
+  "metrics": {
+    "costUsd": 1.07,
+    "latencyMs": 101000
+  }
+}

--- a/results/swe-bench-pro/dataset.json
+++ b/results/swe-bench-pro/dataset.json
@@ -1,0 +1,8 @@
+{
+  "$comment": [
+    "SWE-bench Pro, run through the anti-cheat proxy (2026-08-07)."
+  ],
+  "name": "swe-bench-pro",
+  "sizeLabel": "XL",
+  "taskCount": 731
+}


### PR DESCRIPTION
https://github.com/JetBrains/jetbrains-ai-platform/pull/3861/changes

Results published to this repo -> later in build-time extracted to CLI and analytics for projections and estimations "how much EmbArk saved?"