### PR TITLE
#37 added a basic marketplace.json file to allow installing this repo as an extension marketplace in Junie

### DIFF
--- a/.junie-extension/marketplace.json
+++ b/.junie-extension/marketplace.json
@@ -1,0 +1,32 @@
+{
+  "name": "jbcontext",
+  "owner": {
+    "name": "JetBrains",
+    "email": "junie@jetbrains.com"
+  },
+  "metadata": {
+    "description": "Open integrations for JetBrains Context, including skills, agents, instructions, hooks, and MCP configuration.",
+    "version": "1.0.0",
+    "homepage": "https://github.com/JetBrains/context"
+  },
+  "extensions": [
+    {
+      "name": "jbcontext",
+      "source": ".",
+      "description": "Skills, agents, instructions, hooks, and MCP configuration for JetBrains jbcontext.",
+      "version": "1.0.0",
+      "author": {
+        "name": "JetBrains"
+      },
+      "category": "developer-tools",
+      "homepage": "https://github.com/JetBrains/context",
+      "keywords": [
+        "jbcontext",
+        "code-search",
+        "skills",
+        "agents",
+        "mcp"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is regarding #37.

:warning:So far, this is only a draft, as there are some points i could not quite decide on:
- how will versioning be handled?
- currently, the entire repo is referenced as a single extension. Is there any usecase to split it into multiple extensions like it is done on the JetBrains marketplace "Junie Extensions" https://github.com/JetBrains/junie-extensions ?
- is the email junie@jetbrains.com correct?

Please, feel free to edit my PR as you like, or leave me a comment on how i may improve this :)

Thanks in advance!